### PR TITLE
update jogs and remove deprecated api (typst 0.13)

### DIFF
--- a/typst-package/mj.typ
+++ b/typst-package/mj.typ
@@ -1,12 +1,12 @@
-#import "@preview/jogs:0.2.2": compile-js, call-js-function
+#import "@preview/jogs:0.2.4": compile-js, call-js-function
 
 #let mj-src = read("./mj.js")
 #let mj-bytecode = compile-js(mj-src)
 
-#let natural-image(..args) = style(styles => {
-  let (width, height) = measure(image.decode(..args), styles)
-  image.decode(..args, width: width, height: height)
-})
+#let natural-image(..args) = context {
+  let (width, height) = measure(image(..args))
+  image(..args, width: width, height: height)
+}
 
 #let get-text(src) = {
   if type(src) == str {
@@ -16,18 +16,18 @@
   }
 }
 
-#let render(src, inline: false) = style(styles => {
+#let render(src, inline: false) = context {
   let src = get-text(src)
-  let (width, height) = measure(h(1em), styles)
+  let (width, height) = measure(h(1em))
   let size = width
   let passed-size = size / 1.21 // katex is 1.21x larger, I dont find things about mathjax but it seems to be the same
   // https://katex.org/docs/font
   let result = call-js-function(mj-bytecode, "mj", src, inline, passed-size.pt())
-  let img = natural-image(result.svg, format: "svg")
+  let img = natural-image(bytes(result.svg), format: "svg")
   let ex = result.vertical_align
   if inline {
     box(move(box(img), dy: -ex * 0.5em))
   } else {
     align(center, img)
   }
-})
+}


### PR DESCRIPTION
I've updated the dependencies and removed deprecated APIs in this package to make it compatible with the latest version of Typst. 

I need this package for my work on ox-typst, an exporter that converts Org-mode files to Typst. I've updated the dependencies to work with the latest Typst Universe, as the current version has a problem with LaTeX syntax during conversion. Could you please review and merge my changes?